### PR TITLE
Refactor user functionality to use new MB_Configuration method

### DIFF
--- a/mbc-externalApplications-events.config.inc
+++ b/mbc-externalApplications-events.config.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * Message Broker configuration settings for mbp-user-import
+ * Message Broker configuration settings for mbp-user-import events.
  */
  
 use DoSomething\MB_Toolbox\MB_Configuration;

--- a/mbc-externalApplications-user.config.inc
+++ b/mbc-externalApplications-user.config.inc
@@ -1,6 +1,6 @@
 <?php
 /**
- * Message Broker configuration settings for mbp-user-import
+ * Message Broker configuration settings for mbp-user-import users.
  */
  
 use DoSomething\MB_Toolbox\MB_Configuration;
@@ -9,7 +9,7 @@ use DoSomething\MB_Toolbox\MB_Configuration;
 // symlinks in the project directory point to the actual location of the files
 // Load configuration settings common to the Message Broker system
 // symlinks in the project directory point to the actual location of the files
-require_once __DIR__ . '/messagebroker-config/mb-secure-config.inc';
+require_once CONFIG_PATH . '/mb-secure-config.inc';
 
 // Settings
 $credentials = array(
@@ -27,27 +27,5 @@ $settings = array(
   'ds_drupal_api_port' => getenv('DS_DRUPAL_API_PORT'),
 );
 
-$config = array();
-$configSource = __DIR__ . '/messagebroker-config/mb_config.json';
-$mb_config = new MB_Configuration($configSource, $settings);
-$externalApplicationsExchange = $mb_config->exchangeSettings('directExternalApplicationsExchange');
-
-$config = array(
-  'exchange' => array(
-    'name' => $externalApplicationsExchange->name,
-    'type' => $externalApplicationsExchange->type,
-    'passive' => $externalApplicationsExchange->passive,
-    'durable' => $externalApplicationsExchange->durable,
-    'auto_delete' => $externalApplicationsExchange->auto_delete,
-  ),
-  'queue' => array(
-    array(
-      'name' => $externalApplicationsExchange->queues->externalApplicationUserQueue->name,
-      'passive' => $externalApplicationsExchange->queues->externalApplicationUserQueue->passive,
-      'durable' =>  $externalApplicationsExchange->queues->externalApplicationUserQueue->durable,
-      'exclusive' =>  $externalApplicationsExchange->queues->externalApplicationUserQueue->exclusive,
-      'auto_delete' =>  $externalApplicationsExchange->queues->externalApplicationUserQueue->auto_delete,
-      'bindingKey' => $externalApplicationsExchange->queues->externalApplicationUserQueue->binding_key,
-    ),
-  ),
-);
+$mbConfig = new MB_Configuration($settings, CONFIG_PATH . '/mb_config.json');
+$config = $mbConfig->constructConfig('directExternalApplicationsExchange', array('externalApplicationUserQueue'));

--- a/mbc-externalApplications-user.php
+++ b/mbc-externalApplications-user.php
@@ -12,7 +12,8 @@
  *   - Mandrill transactional signup email message if a Drupal user is created
  */
 
- date_default_timezone_set('America/New_York');
+date_default_timezone_set('America/New_York');
+define('CONFIG_PATH',  __DIR__ . '/messagebroker-config');
 
 // Load up the Composer autoload magic
 require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
Fixes #26 

Further refactoring to use `MB_Configuration->constructConfig()` method.